### PR TITLE
Add 'Find in Open Files' feature

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -55,12 +55,14 @@
   'cmd-enter': 'project-find:confirm'
   'cmd-alt-/': 'project-find:toggle-regex-option'
   'cmd-alt-c': 'project-find:toggle-case-option'
+  'cmd-alt-o': 'project-find:toggle-open-files-option'
   'cmd-alt-w': 'project-find:toggle-whole-word-option'
 
 '.platform-win32 .project-find, .platform-linux .project-find':
   'ctrl-enter': 'project-find:confirm'
   'ctrl-alt-/': 'project-find:toggle-regex-option'
   'ctrl-alt-c': 'project-find:toggle-case-option'
+  'ctrl-alt-o': 'project-find:toggle-open-files-option'
   'ctrl-alt-w': 'project-find:toggle-whole-word-option'
 
 '.find-and-replace, .project-find, .project-find .results-view':

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -9,6 +9,7 @@ Params = [
   'wholeWord'
   'caseSensitive'
   'inCurrentSelection'
+  'openFiles'
 ]
 
 module.exports =
@@ -23,6 +24,7 @@ class FindOptions
     @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
     @wholeWord = state.wholeWord ? atom.config.get('find-and-replace.wholeWord') ? false
     @inCurrentSelection = state.inCurrentSelection ? atom.config.get('find-and-replace.inCurrentSelection') ? false
+    @openFiles = state.openFiles ? atom.config.get('find-and-replace.openFiles') ? false
 
   onDidChange: (callback) ->
     @emitter.on('did-change', callback)

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -89,6 +89,11 @@ class FindView extends View
           <path d="M4,10.5 L4,12.5 L4,13 L5,13 L5,12.5 L5,10.5 L5,10 L4,10 L4,10.5 L4,10.5 Z"></path>
           <path d="M15,10.5 L15,12.5 L15,13 L16,13 L16,12.5 L16,10.5 L16,10 L15,10 L15,10.5 L15,10.5 Z"></path>
         </symbol>
+
+        <symbol id="find-and-replace-icon-files" viewBox="0 0 12 16" stroke="none" fill-rule="evenodd">
+          <path d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"/>
+          </svg>
+        </symbol>
       </svg>'
 
   initialize: (@model, {@findHistoryCycler, @replaceHistoryCycler}) ->

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -61,6 +61,8 @@ class ProjectFindView extends View
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
             @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
+            @button outlet: 'openFilesOptionButton', class: 'btn option-open-files', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-files" /></svg>'
 
       @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
@@ -82,6 +84,7 @@ class ProjectFindView extends View
     @pathsHistoryCycler.addEditorElement(@pathsEditor.element)
 
     @onlyRunIfChanged = true
+    @savedPathsPattern = ''
 
     @clearMessages()
     @updateOptionViews()
@@ -115,6 +118,11 @@ class ProjectFindView extends View
       keyBindingCommand: 'project-find:toggle-whole-word-option',
       keyBindingTarget: @findEditor.element
 
+    subs.add atom.tooltips.add @openFilesOptionButton,
+      title: "Open Files",
+      keyBindingCommand: 'project-find:toggle-open-files-option',
+      keyBindingTarget: @findEditor.element
+
     subs.add atom.tooltips.add @findAllButton,
       title: "Find All",
       keyBindingCommand: 'find-and-replace:search',
@@ -144,7 +152,21 @@ class ProjectFindView extends View
       'project-find:toggle-regex-option': => @toggleRegexOption()
       'project-find:toggle-case-option': => @toggleCaseOption()
       'project-find:toggle-whole-word-option': => @toggleWholeWordOption()
+      'project-find:toggle-open-files-option': => @toggleOpenFilesOption()
       'project-find:replace-all': => @replaceAll()
+
+    @subscriptions.add atom.workspace.onDidDestroyPaneItem =>
+      if @openFilesOptionButton? and atom.workspace.getTextEditors().length == 0
+        @openFilesOptionButton.disable()
+        @updateOptionsLabel()
+      else if @openFilesOptionButton? and @model.getFindOptions().openFiles
+        @search(onlyRunIfActive: true, openFiles: true)
+
+    @subscriptions.add atom.workspace.onDidAddTextEditor =>
+      if @openFilesOptionButton? and @openFilesOptionButton.isDisabled()
+        @openFilesOptionButton.enable()
+        @updateOptionsLabel()
+        @search(onlyRunIfActive: true, openFiles: true)
 
     updateInterfaceForSearching = =>
       @setInfoMessage('Searching...')
@@ -171,6 +193,7 @@ class ProjectFindView extends View
     @regexOptionButton.click => @toggleRegexOption()
     @caseOptionButton.click => @toggleCaseOption()
     @wholeWordOptionButton.click => @toggleWholeWordOption()
+    @openFilesOptionButton.click => @toggleOpenFilesOption()
     @replaceAllButton.on 'click', => @replaceAll()
     @findAllButton.on 'click', => @search()
 
@@ -239,6 +262,10 @@ class ProjectFindView extends View
     pathsPattern = @pathsEditor.getText()
     replacePattern = @replaceEditor.getText()
 
+    if @model.getFindOptions().openFiles and not @openFilesOptionButton.isDisabled()
+      paths = @getOpenFilePaths()
+      pathsPattern = paths.join(',')
+
     {onlyRunIfActive, onlyRunIfChanged} = options
     return Promise.resolve() if (onlyRunIfActive and not @model.active) or not findPattern
 
@@ -290,6 +317,13 @@ class ProjectFindView extends View
       require('path').dirname(elementPath)
     else
       elementPath
+
+  relPathFromTextEditor: (editor) ->
+    [rootPath, relPath] = atom.project.relativizePath(editor.getPath())
+    if rootPath? and atom.project.getDirectories().length > 1
+      relPath = path.join(path.basename(rootPath), relPath)
+      relPath = relPath.substring(0, relPath.length-1) + '[' + relPath.slice(-1) + ']'
+    relPath
 
   findInCurrentlySelectedDirectory: (selectedElement) ->
     if absPath = @directoryPathForElement(selectedElement)
@@ -369,13 +403,22 @@ class ProjectFindView extends View
       label.push('Case Sensitive')
     else
       label.push('Case Insensitive')
+    label.push('Open Files') if @model.getFindOptions().openFiles and not @openFilesOptionButton.isDisabled()
     label.push('Whole Word') if @model.getFindOptions().wholeWord
     @optionsLabel.text(label.join(', '))
+
+  updatePathsEditor: (openFilesOptionWillBeEnabled) ->
+    if openFilesOptionWillBeEnabled
+      @savedPathsPattern = @pathsEditor.getText()
+      @pathsEditor.setText 'Searching open files only'
+    else
+      @pathsEditor.setText @savedPathsPattern
 
   updateOptionButtons: ->
     @setOptionButtonState(@regexOptionButton, @model.getFindOptions().useRegex)
     @setOptionButtonState(@caseOptionButton, @model.getFindOptions().caseSensitive)
     @setOptionButtonState(@wholeWordOptionButton, @model.getFindOptions().wholeWord)
+    @setOptionButtonState(@openFilesOptionButton, @model.getFindOptions().openFiles)
 
   setOptionButtonState: (optionButton, selected) ->
     if selected
@@ -391,3 +434,10 @@ class ProjectFindView extends View
 
   toggleWholeWordOption: ->
     @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().wholeWord)
+
+  toggleOpenFilesOption: ->
+    @updatePathsEditor(not @model.getFindOptions().openFiles)
+    @search(onlyRunIfActive: true, openFiles: not @model.getFindOptions().openFiles)
+
+  getOpenFilePaths: ->
+    paths = @relPathFromTextEditor(e) for e in atom.workspace.getTextEditors()


### PR DESCRIPTION
## PR FOR FEEDBACK ONLY

I'll open a new PR against `atom/find-and-replace` when the feature is complete.
- Closes #241, #354
### Where should the reviewer start?

`lib/project-find-view.coffee`
- specifically [the part where we commandeer the pathsEditor](https://github.com/trevdor/find-and-replace/compare/master...trevdor:findInOpenFiles?expand=1#diff-e950e2b0ff52c023d87c2a6e95144bcfR265) to only search open file paths
### Request for Comment
1. What's a better way to search within specific paths without my ugly [file glob hack](https://github.com/trevdor/find-and-replace/compare/master...trevdor:findInOpenFiles?expand=1#diff-e950e2b0ff52c023d87c2a6e95144bcfR325)?
   - I did this because searching with exact paths returns no results. Seems to be a quirk of the underlying JS regex engine. However, it works with file globs. Wrapping the last character of the filename in `[]` seems to do the job safely. But this is undeniably hacky.
2. Should 'find in open files' be additive or exclusive? 
   - I opted for exclusive. That is, you search open files or you search based on paths, not both. I couldn't decide if an additive implementation would search the intersection or the union of open files and given paths.
3. Since I'm hijacking the paths editor to search open files, should the paths of all open files be listed in the paths editor while it is enabled? 
   - I opted not to show the open file paths as I assume folks generally understand "find in open files" and it would get noisy real quickly with the paths scrolling out of the visible portion of the editor. I think this is also more consistent with my exclusivity choice above, as listing the file paths suggests you can edit them.
### To Do
- [ ] **Write tests for the new functionality**
  - Didn't wanna test the above behaviors until they were nailed down. 
- [ ]  **Better messaging when 'find in open files' is enabled**
  - Currently, I replace what's in the pathsEditor with a note that we are 'Searching open files only'. I wanted this to be rendered in the style of the placeholder text, but could not find a way to disable the pathsEditor (`@pathsEditor.disable()` didn't work) or manipulate the placeholder text without trouble. People should not be able to edit the 'Searching open files only' message as if it were a file pattern, and ideally, the whole pathsEditor would be clearly disabled when 'find in open files' is in use. I would like to investigate using a note like the '<#> of <total>' seen in 'Find in current buffer' text input (e.g. '3 of 3' in the screenshot on #562)
- [ ]  **Option state saving bug**
  - If the 'find in open files' option is disabled due to the last open tab being closed, but then it is reenabled because a file is opened, under certain conditions the state of the option is set incorrectly. I intend to fix this, perhaps by explicitly storing off the state when disabling the option, similar to [what I do for restoring the pathsEditor string](https://github.com/trevdor/find-and-replace/compare/master...trevdor:findInOpenFiles?expand=1#diff-e950e2b0ff52c023d87c2a6e95144bcfR415).
